### PR TITLE
Fix pentagram chances

### DIFF
--- a/data.json
+++ b/data.json
@@ -685,7 +685,7 @@
             },
             {
                 "name": "Leveling",
-                "value": "(1) Base \n(2) Cooldown -10 \n(3) 20% not to erase \n(4) Cooldown -10 \n(5) 40% not to erase \n(6) Cooldown -10 \n(7) 60% not to erase",
+                "value": "(1) Base \n(2) Cooldown -10 \n(3) 25% not to erase \n(4) Cooldown -10 \n(5) 45% not to erase \n(6) Cooldown -10 \n(7) 65% not to erase",
                 "inline": false
             }
         ]


### PR DESCRIPTION
From the code:
```js
[
  {
    level: 1,
    bulletType: unknown60['PENTAGRAM'],
    name: 'Pentagram',
    description: 'Erases everything in sight.',
    tips: 'Best with: cooldown and luck only.',
    texture: 'items',
    frameName: 'Pentagram.png',
    isUnlocked: !1,
    poolLimit: 10,
    rarity: 60,
    interval: 90000,
    repeatInterval: 0,
    power: 0,
    area: 1,
    speed: 1,
    amount: 1,
    knockback: -2,
    chance: 0.1,
    hitsWalls: !1,
  },
  { interval: -10000 },
  { chance: 0.15, desc: '25% chance to not erase items.' },
  { interval: -10000 },
  { chance: 0.2, desc: '45% chance to not erase items.' },
  { interval: -10000 },
  { chance: 0.2, desc: '65% chance to not erase items.' },
]
```

And this also matches the in-game description. Also, it starts with a 10% chance to not erase stuff. I feel like this should be mentioned somewhere but not sure where. Seems like all the other items also don't mention their starting stats 🤔 